### PR TITLE
[Refactor] 포인트 조회, 포인트 차감 API 에러처리 수정

### DIFF
--- a/src/main/java/ttakkeun/ttakkeun_server/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/apiPayLoad/code/status/ErrorStatus.java
@@ -41,7 +41,10 @@ public enum ErrorStatus implements BaseErrorCode {
     PET_NOT_FOUND(HttpStatus.BAD_REQUEST, "PET4002", "해당 사용자의 반려동물이 아닙니다."),
 
     //이미지 에러
-    IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "IMAGE4000", "이미지가 첨부되지 않았습다.");
+    IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "IMAGE4000", "이미지가 첨부되지 않았습니다."),
+
+    // point 에러
+    MEMBER_HAS_NO_POINT(HttpStatus.NOT_FOUND, "POINT4001", "해당하는 멤버에게 포인트 값이 존재하지 않습니다. DB 관리자에게 문의해주세요");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/ttakkeun/ttakkeun_server/controller/DiagnoseController.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/controller/DiagnoseController.java
@@ -42,8 +42,8 @@ public class DiagnoseController {
             ApiResponse<GetMyPointResponseDTO> response = ApiResponse.of(SuccessStatus._OK, new GetMyPointResponseDTO(point));
             return ResponseEntity.ok(response);
         } catch (NoSuchElementException e) {
-            ApiResponse<GetMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_NOT_FOUND, null);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            ApiResponse<GetMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_HAS_NO_POINT, null);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         } catch (UsernameNotFoundException e) {
             ApiResponse<GetMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus._UNAUTHORIZED, null);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
@@ -96,8 +96,8 @@ public class DiagnoseController {
             ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.of(SuccessStatus._OK, new UpdateMyPointResponseDTO(point));
             return ResponseEntity.ok(response);
         } catch (NoSuchElementException e) {
-            ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_NOT_FOUND, null);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_HAS_NO_POINT, null);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         } catch (UsernameNotFoundException e) {
             ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus._UNAUTHORIZED, null);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);

--- a/src/main/java/ttakkeun/ttakkeun_server/controller/DiagnoseTestController.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/controller/DiagnoseTestController.java
@@ -40,8 +40,8 @@ public class DiagnoseTestController {
             ApiResponse<GetMyPointResponseDTO> response = ApiResponse.of(SuccessStatus._OK, new GetMyPointResponseDTO(point));
             return ResponseEntity.ok(response);
         } catch (NoSuchElementException e) {
-            ApiResponse<GetMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_NOT_FOUND, null);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            ApiResponse<GetMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_HAS_NO_POINT, null);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         } catch (UsernameNotFoundException e) {
             ApiResponse<GetMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus._UNAUTHORIZED, null);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
@@ -55,7 +55,7 @@ public class DiagnoseTestController {
     // 진단 결과 목록을 조회하는 API
     // 페이징 처리, 한 페이지당 10개 고정
     // size가 고정이므로 Path Variable로 처리하였음
-    @Operation(summary = "진단 결과 목록 조회 API")
+    @Operation(summary = "진단 결과 목록 조회 API 테스트")
     @GetMapping("/{pet_id}/{category}/{page}")
     public ResponseEntity<ApiResponse<GetMyDiagnoseListResponseDTO>> getDiagnoseListByPet(@PathVariable(name = "pet_id") Long petId,
                                                                                           @PathVariable(name = "category") Category category,
@@ -90,8 +90,8 @@ public class DiagnoseTestController {
             ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.of(SuccessStatus._OK, new UpdateMyPointResponseDTO(point));
             return ResponseEntity.ok(response);
         } catch (NoSuchElementException e) {
-            ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_NOT_FOUND, null);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus.MEMBER_HAS_NO_POINT, null);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         } catch (UsernameNotFoundException e) {
             ApiResponse<UpdateMyPointResponseDTO> response = ApiResponse.ofFailure(ErrorStatus._UNAUTHORIZED, null);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);

--- a/src/main/java/ttakkeun/ttakkeun_server/service/DiagnoseService.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/service/DiagnoseService.java
@@ -55,7 +55,7 @@ public class DiagnoseService {
         if (!pointOpt.isPresent()) {
             // Optional 객체에서 값이 비어있는 경우 예외를 던짐
             // 0 반환에서 오류 발생하도록 수정함
-            throw new NoSuchElementException("Member with ID " + memberId + " not found");
+            throw new NoSuchElementException("Member with ID " + memberId + " has no point");
         }
 
         Point point = pointOpt.get(); // Optinal 객체에서 point를 가져옴
@@ -112,7 +112,7 @@ public class DiagnoseService {
 
         if (!pointOpt.isPresent()) {
             // Optional 객체에서 값이 비어있는 경우 예외를 던짐
-            throw new NoSuchElementException("Member with ID " + memberId + " not found");
+            throw new NoSuchElementException("Member with ID " + memberId + " has no point");
         }
 
         Point point = pointOpt.get(); // Optinal 객체에서 point를 가져옴


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
- 포인트 조회, 포인트 차감 API 에러처리 수정
  - 기존에는 member 값이 정상적이어도 point 테이블에 member에 해당하는 값이 없으면 member가 없다는 400 에러 발생
  - 해당 부분을 해당하는 멤버에게 포인트값이 존재하지 않는다는 404 에러가 발생하도록 수정하였음
  - member값이 유효하지 않으면 사용자가 로그인을 다시 시도해볼 수 있지만, 멤버에게 포인트값이 존재하지 않는 건 서버측의 문제이므로 404 에러로 처리함

- 수정 후 실행 결과
![스크린샷 2024-08-12 162002](https://github.com/user-attachments/assets/b9421952-2740-4edf-add1-2c1c34039711)
![스크린샷 2024-08-12 162023](https://github.com/user-attachments/assets/b0e0be93-8261-4f48-9e62-4f27a9ec6c49)


## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
