### PR TITLE
[Refactor] 포인트 조회 API 수정

### DIFF
--- a/src/main/java/ttakkeun/ttakkeun_server/controller/DiagnoseTestController.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/controller/DiagnoseTestController.java
@@ -13,11 +13,13 @@ import ttakkeun.ttakkeun_server.apiPayLoad.code.status.SuccessStatus;
 import ttakkeun.ttakkeun_server.dto.diagnose.*;
 import ttakkeun.ttakkeun_server.entity.Member;
 import ttakkeun.ttakkeun_server.entity.enums.Category;
+import ttakkeun.ttakkeun_server.repository.MemberRepository;
 import ttakkeun.ttakkeun_server.service.DiagnoseService.DiagnoseChatGPTService;
 import ttakkeun.ttakkeun_server.service.DiagnoseService.DiagnoseService;
 //import ttakkeun.ttakkeun_server.dto.UpdateProductsDTO;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static ttakkeun.ttakkeun_server.apiPayLoad.code.status.ErrorStatus.PET_ID_NOT_AVAILABLE;
 import static ttakkeun.ttakkeun_server.apiPayLoad.code.status.ErrorStatus.RECORD_NOT_FOUND;
@@ -31,6 +33,8 @@ public class DiagnoseTestController {
 
     @Autowired
     private DiagnoseChatGPTService diagnoseChatGPTService;
+
+    private MemberRepository memberRepository;
 
     // 진단 버튼 클릭시 사용자의 포인트를 조회하는 API
     @Operation(summary = "사용자 포인트 조회 테스트 API")

--- a/src/main/java/ttakkeun/ttakkeun_server/entity/Point.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/entity/Point.java
@@ -20,7 +20,7 @@ public class Point {
 
     private Integer points;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @MapsId // 'memberId'를 'Member' 엔티티의 PK와 매핑
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/ttakkeun/ttakkeun_server/repository/MemberRepository.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByAppleSub(String sub);
+
+    Optional<Member> findByMemberId(Long memberId);
 }


### PR DESCRIPTION
포인트 조회를 시도했을 때 사용자에게 포인트값이 존재하지 않을 경우
DB에 값을 생성하도록 함
초기 point값은 10점으로 넣음

## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
- 포인트값이 아예 존재하지 않는 사용자의 경우, 조회시 DB에 값을 새로 생성함
  ![image](https://github.com/user-attachments/assets/c4028c99-28b4-47e0-b68a-bbdba5d038ec)


## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
