### PR TITLE
[Feat] 일지 삭제 API

### DIFF
--- a/src/main/java/ttakkeun/ttakkeun_server/entity/Pet.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/entity/Pet.java
@@ -48,11 +48,6 @@ public class Pet extends BaseEntity {
     @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL)
     private List<Todo> todoList = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL)
-    private List<Result> resultList = new ArrayList<>();
-
-
     public void updateImage(String imageUrl) {
         this.petImageUrl = imageUrl;
     }

--- a/src/main/java/ttakkeun/ttakkeun_server/entity/Pet.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/entity/Pet.java
@@ -48,6 +48,10 @@ public class Pet extends BaseEntity {
     @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL)
     private List<Todo> todoList = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL)
+    private List<Result> resultList = new ArrayList<>();
+
 
     public void updateImage(String imageUrl) {
         this.petImageUrl = imageUrl;

--- a/src/main/java/ttakkeun/ttakkeun_server/entity/Result.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/entity/Result.java
@@ -25,9 +25,14 @@ public class Result extends BaseEntity {
     @OneToMany(mappedBy = "result", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<ResultProduct> ProductList = new ArrayList<>();
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id")
     private Record record;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id")
+    private Pet pet;
 
     @Enumerated(EnumType.STRING)
     private Category resultCategory;

--- a/src/main/java/ttakkeun/ttakkeun_server/entity/Result.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/entity/Result.java
@@ -25,7 +25,6 @@ public class Result extends BaseEntity {
     @OneToMany(mappedBy = "result", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private List<ResultProduct> ProductList = new ArrayList<>();
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id")
     private Record record;
@@ -42,4 +41,8 @@ public class Result extends BaseEntity {
     private String resultDetail;
 
     private String resultCare;
+
+    public void setRecord(Record record) {
+        this.record = record;
+    }
 }

--- a/src/main/java/ttakkeun/ttakkeun_server/repository/ResultRepository.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/repository/ResultRepository.java
@@ -4,6 +4,7 @@ import feign.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
+import ttakkeun.ttakkeun_server.entity.Pet;
 import ttakkeun.ttakkeun_server.entity.Record;
 import ttakkeun.ttakkeun_server.entity.enums.Category;
 import ttakkeun.ttakkeun_server.repository.custom.CustomResultRepository;
@@ -12,6 +13,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ttakkeun.ttakkeun_server.entity.Result;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,5 +28,7 @@ public interface ResultRepository extends JpaRepository<Result, Long>, CustomRes
     @Query("SELECT r FROM Result r WHERE r.record.pet.petId = :petId AND r.resultCategory = :category")
     Page<Result> findByPetIdAndCategory(@Param("petId") Long petId, @Param("category") Category category, Pageable pageable);
 
-    void deleteByRecord(Record record);
+    List<Result> findByRecordIsNullAndPet(Pet pet);
+
+    List<Result> findByRecord(Record record);
 }

--- a/src/main/java/ttakkeun/ttakkeun_server/service/DiagnoseService/DiagnoseChatGPTService.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/service/DiagnoseService/DiagnoseChatGPTService.java
@@ -170,6 +170,7 @@ public class DiagnoseChatGPTService {
                     .resultCare(care)
                     .record(record)
                     .resultCategory(category)
+                    .pet(pet)   // pet_id 저장
                     .build();
 
 

--- a/src/main/java/ttakkeun/ttakkeun_server/service/RecordService.java
+++ b/src/main/java/ttakkeun/ttakkeun_server/service/RecordService.java
@@ -40,6 +40,7 @@ public class RecordService {
     private final UserAnswerRepository userAnswerRepository;
     private final ImageRepository imageRepository;
     private final S3ImageService s3ImageService;
+    private final ResultRepository resultRepository;
 
     public List<RecordListResponseDto> getRecordsByCategory(Member member, Long petId, Category category, int page, int size) {
         if (member == null || member.getMemberId() == null) {
@@ -168,8 +169,18 @@ public class RecordService {
     }
 
     public RecordResponseDTO.DeleteResultDTO deleteRecord(Long recordId) {
-        Optional<Record> record = recordRepository.findById(recordId);
-        if (record.isPresent()) {
+        Optional<Record> recordOptional = recordRepository.findById(recordId);
+
+        if (recordOptional.isPresent()) {
+            Record record = recordOptional.get();
+
+            List<Result> results = resultRepository.findByRecord(record);
+
+            for (Result result : results) {
+                result.setRecord(null);
+                resultRepository.save(result);
+            }
+
             recordRepository.deleteById(recordId);
             return RecordResponseDTO.DeleteResultDTO.builder()
                     .message("일지 삭제에 성공하였습니다.")


### PR DESCRIPTION
## ✨ PR 유형

기존 일지 삭제 API 및 펫 삭제 API 수정

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

기존 일지 삭제는 API는 해당 일지로 진단을 생성할 경우 삭제가 되지 않는 오류가 있었음
해결을 위해 진단 결과 (result)에 pet_id를 FK로 추가함.
그리하여 진단 생성 시 pet_id도 같이 저장하고, 일지 삭제시 해당 진단의 record_id (일지id)는 null로 처리.
펫 삭제시에는 연관된 항목 뿐 아니라, 진단 중 record_id가 null 이면서 pet_id가 동일한 진단도 삭제하도록 구현.
테스트 결과 정상적으로 모두 삭제되는 것을 확인.


## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]

## 📌 리뷰 포인트

기존에 생성된 모든 result는 pet_id가 null이므로 현재 방식으로는 삭제 불가하니 유의바람.

엔티티가 변경되었으니 주의깊게 확인해주길 바랍니다.
erd도 변경하였음

![image](https://github.com/user-attachments/assets/16f330dc-15d5-44ec-84bc-64b74ca7c0ce)


## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
